### PR TITLE
Add a diagnostic plot type.

### DIFF
--- a/pmwg_diagnostic.R
+++ b/pmwg_diagnostic.R
@@ -1,0 +1,46 @@
+### Plotting function for diagnosing covariance matrix problems
+#### Contributed by Gavin Cooper
+
+diagnostic_plot <- function(
+      sampler,
+      from = 1,
+      to = sampler$samples$idx,
+      inv = FALSE,
+      diag = FALSE,
+      det = FALSE) {
+  plot_title <- ifelse(inv, "Inverse of Covariance Matrix", "Covariance Matrix")
+  flags <- c(inv & diag, inv & !diag, !inv & diag, !inv & !diag)
+  ax <- c("diagonal", "inverse matrix", "variance vector", "covariance matrix")
+
+  if (det) {
+    plot_yaxis <- "Matrix Determinant"
+  } else {
+    plot_yaxis <- paste("Mean of", ax[which(flags)])
+  }
+
+  #Main plot
+  plot(
+    apply(sampler$samples$theta_sig[, , from:to], 3, function(x) {
+      if (inv) {
+        x <- MASS::ginv(x)
+      }
+      if (det) {
+        det(x, log = TRUE)
+      } else {
+        if (diag) {
+          x <- diag(x)
+        }
+        mean(x)
+      }
+    }),
+    main = plot_title, xlab = "Iteration", ylab = plot_yaxis, type = "l"
+  )
+
+  # Stage markers
+  stages <- data.frame(unclass(rle(sampler$samples$stage[from:to])))
+  stages$cumsum <- cumsum(stages$lengths)
+  abline(v = stages$cumsum)
+  coords <- par("usr")
+  ypos <- coords[3] + (coords[4] - coords[3]) / 100
+  text(stages$cumsum, ypos, paste(stages$values, "<-"), adj = c(1, 0))
+}


### PR DESCRIPTION
Based on work investigating problems with the covariance matrix where
the variance would drop over time (and thus inverse of covariance matrix
would increase). This diagnostic plot combines all aspects of that work.

The only required argument is the sampler object to draw from.

Optional arguments include:

* `from` and `to` the index of the first and last sample you want to plot.
* `inv = TRUE` calculates the inverse of the covariance matrix
* `diag = TRUE` discards off diagonals of the covariance matrix (plotting only
variances)
* `det = TRUE` Calculates the determinant of the covariance matrix
instead.

Additionally the plot creates vertical lines representing transitions
between stages of the sampler